### PR TITLE
fixed jump animation to end at the intended position

### DIFF
--- a/src/components/jump.module.css
+++ b/src/components/jump.module.css
@@ -4,9 +4,10 @@
   transition-duration: var(--animation-slow);
   transition-property: transform opacity;
   transition-timing-function: var(--animation-ease);
+  transform: translate3d(0, 10vh, 0);
 }
 
 .visible {
-  transform: translate3d(0, -10vh, 0);
+  transform: translate3d(0, 0, 0);
   opacity: 1;
 }


### PR DESCRIPTION
The old animation moved the blocks away from their intended position. Changed the animation to begin with an offset and thus end in the intended position.