### PR TITLE
Fix/lighthouse performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ yarn-error.log
 fonts/*
 !fonts/index.css
 !fonts/fonts.tar.enc
+
+# IntelliJ files
+.idea/

--- a/fonts/index.css
+++ b/fonts/index.css
@@ -5,7 +5,9 @@
     url("./apercu-mono-regular-pro.woff2") format("woff2"),
     url("./apercu-mono-regular-pro.woff") format("woff"),
     url("./apercu-mono-regular-pro.ttf") format("truetype");
-  font-weight: italic;
+  /* show text while fonts are loading https://web.dev/font-display/ */
+  font-display: swap;
+  font-weight: normal;
   font-style: italic;
 }
 
@@ -16,6 +18,7 @@
     url("./apercu-regular-pro.woff2") format("woff2"),
     url("./apercu-regular-pro.woff") format("woff"),
     url("./apercu-regular-pro.ttf") format("truetype");
+  font-display: swap;
   font-weight: normal;
   font-style: normal;
 }
@@ -27,6 +30,7 @@
     url("./apercu-bold-pro.woff2") format("woff2"),
     url("./apercu-bold-pro.woff") format("woff"),
     url("./apercu-bold-pro.ttf") format("truetype");
+  font-display: swap;
   font-weight: bold;
-  font-style: bold;
+  font-style: normal;
 }

--- a/src/blocks/components/blog-post-highlights.js
+++ b/src/blocks/components/blog-post-highlights.js
@@ -21,7 +21,7 @@ const BlogPostHighlights = ({ button, action }) => {
             }
             image {
               title
-              fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
+              fluid(sizes: "(max-width: 1200px) 512px, 1600px") {
                 ...GatsbyContentfulFluid_withWebp
               }
             }

--- a/src/blocks/components/blog-post-highlights.js
+++ b/src/blocks/components/blog-post-highlights.js
@@ -20,7 +20,8 @@ const BlogPostHighlights = ({ button, action }) => {
               name
             }
             image {
-              fluid(maxWidth: 2048) {
+              title
+              fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
                 ...GatsbyContentfulFluid_withWebp
               }
             }
@@ -49,7 +50,12 @@ const BlogPostHighlights = ({ button, action }) => {
             title={post.title}
             subtitle={`By ${post.author.name}`}
             link={action}
-            image={<Image fluid={post.image.fluid} />}
+            image={
+              <Image
+                fluid={post.image.fluid}
+                alt={post.image.title || post.title}
+              />
+            }
           />
         )}
       />

--- a/src/blocks/components/blog-post-list.js
+++ b/src/blocks/components/blog-post-list.js
@@ -18,7 +18,7 @@ const BlogPostList = ({ action }) => {
             }
             image {
               title
-              fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
+              fluid(sizes: "(max-width: 1200px) 400px, 1600px") {
                 ...GatsbyContentfulFluid_withWebp
               }
             }

--- a/src/blocks/components/blog-post-list.js
+++ b/src/blocks/components/blog-post-list.js
@@ -17,7 +17,8 @@ const BlogPostList = ({ action }) => {
               name
             }
             image {
-              fluid(maxWidth: 2048) {
+              title
+              fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
                 ...GatsbyContentfulFluid_withWebp
               }
             }
@@ -47,7 +48,12 @@ const BlogPostList = ({ action }) => {
             title={post.title}
             subtitle={`By ${post.author.name}`}
             link={action}
-            image={<Image fluid={post.image.fluid} />}
+            image={
+              <Image
+                fluid={post.image.fluid}
+                alt={post.image.title || post.title}
+              />
+            }
           />
         )}
       />

--- a/src/blocks/components/case-story-highlights.js
+++ b/src/blocks/components/case-story-highlights.js
@@ -18,7 +18,7 @@ const CaseStoryHighlights = ({ button, action }) => {
             title
             client
             image {
-              fluid(maxWidth: 2048) {
+              fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
                 ...GatsbyContentfulFluid_withWebp
               }
             }

--- a/src/blocks/components/case-story-highlights.js
+++ b/src/blocks/components/case-story-highlights.js
@@ -18,7 +18,7 @@ const CaseStoryHighlights = ({ button, action }) => {
             title
             client
             image {
-              fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
+              fluid(sizes: "(max-width: 1200px) 400px, 1600px") {
                 ...GatsbyContentfulFluid_withWebp
               }
             }

--- a/src/blocks/components/case-story-highlights.js
+++ b/src/blocks/components/case-story-highlights.js
@@ -47,7 +47,12 @@ const CaseStoryHighlights = ({ button, action }) => {
             title={story.title}
             subtitle={story.client}
             link={action}
-            image={<Image fluid={story.image.fluid} />}
+            image={
+              <Image
+                fluid={story.image.fluid}
+                alt={story.image.title || story.title}
+              />
+            }
           />
         )}
       />

--- a/src/blocks/components/case-story-list.js
+++ b/src/blocks/components/case-story-list.js
@@ -15,7 +15,8 @@ const CaseStoryList = ({ action }) => {
             title
             client
             image {
-              fluid(maxWidth: 2048) {
+              title
+              fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
                 ...GatsbyContentfulFluid_withWebp
               }
             }
@@ -45,7 +46,12 @@ const CaseStoryList = ({ action }) => {
             title={story.title}
             subtitle={story.client}
             link={action}
-            image={<Image fluid={story.image.fluid} />}
+            image={
+              <Image
+                fluid={story.image.fluid}
+                alt={story.image.title || story.title}
+              />
+            }
           />
         )}
       />

--- a/src/blocks/components/case-story-list.js
+++ b/src/blocks/components/case-story-list.js
@@ -16,7 +16,7 @@ const CaseStoryList = ({ action }) => {
             client
             image {
               title
-              fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
+              fluid(sizes: "(max-width: 1200px) 400px, 1600px") {
                 ...GatsbyContentfulFluid_withWebp
               }
             }

--- a/src/blocks/contact-block.js
+++ b/src/blocks/contact-block.js
@@ -7,7 +7,7 @@ const ContactBlock = ({ data }) => (
   <div className={styles.wrapper}>
     <h2 dangerouslySetInnerHTML={{ __html: data.heading }} />
     <div>
-      <Image fluid={data.contact.image.fluid} />
+      <Image fluid={data.contact.image.fluid} alt={data.contact.image.title} />
       <div>
         <h5>{data.contact.name}</h5>
         <p>

--- a/src/blocks/contact-block.js
+++ b/src/blocks/contact-block.js
@@ -9,7 +9,7 @@ const ContactBlock = ({ data }) => (
     <div>
       <Image fluid={data.contact.image.fluid} alt={data.contact.image.title} />
       <div>
-        <h5>{data.contact.name}</h5>
+        <h3 className={styles.title}>{data.contact.name}</h3>
         <p>
           {data.contact.position}
           <br />

--- a/src/blocks/contact-block.module.css
+++ b/src/blocks/contact-block.module.css
@@ -16,6 +16,10 @@
   width: 200px;
 }
 
+.title {
+  font-weight: bold;
+}
+
 @media (max-width: 739px) {
   .wrapper > div {
     align-items: flex-start;
@@ -25,7 +29,7 @@
   .wrapper > div > div:first-child {
     height: 145px;
     margin-bottom: 20px;
-    margin-right: 0px;
+    margin-right: 0;
     width: 145px;
   }
 }

--- a/src/blocks/image-block.js
+++ b/src/blocks/image-block.js
@@ -11,7 +11,7 @@ const renderAsset = asset => {
     return <Video key={asset.id} src={`https:${asset.file.url}`} />
   }
 
-  return <Image key={asset.id} fluid={asset.fluid} />
+  return <Image key={asset.id} fluid={asset.fluid} alt={asset.title} />
 }
 
 const ImageBlock = ({ data }) => (

--- a/src/blocks/logos-block.js
+++ b/src/blocks/logos-block.js
@@ -1,10 +1,11 @@
 import React from "react"
+import Image from "gatsby-image"
 
 import styles from "./logos-block.module.css"
 import RichText from "../components/rich-text"
 
 const LogosBlock = ({ data }) => (
-  <section className={styles.wrapper}>
+  <section>
     <div className={styles.content}>
       <h2>{data.heading}</h2>
       {data.content && <RichText document={data.content.json} />}
@@ -12,8 +13,13 @@ const LogosBlock = ({ data }) => (
     <div className={styles.list}>
       <ul>
         {data.images.map(image => (
-          <li key={image.file.url}>
-            <img key={image.file.url} src={image.file.url} alt="Logo" />
+          <li key={image.id}>
+            <Image
+              alt={image.title}
+              className={styles.img}
+              imgStyle={{ objectFit: "contain" }} // override gatsby-image default "cover"
+              fluid={image.fluid}
+            />
           </li>
         ))}
       </ul>

--- a/src/blocks/logos-block.module.css
+++ b/src/blocks/logos-block.module.css
@@ -1,6 +1,5 @@
 .content {
   composes: wrapper from "../styles/text-content.module.css";
-
   padding-bottom: 0;
 }
 
@@ -29,10 +28,10 @@
   min-width: 100%;
 }
 
-.list > ul > li > img {
-  box-sizing: border-box;
-  max-height: 100%;
-  max-width: 100%;
+/* override gatsby-image default style */
+.img {
+  height: 100%;
+  width: 100%;
 }
 
 @media (max-width: 1199px) {

--- a/src/components/block-list.js
+++ b/src/components/block-list.js
@@ -128,7 +128,7 @@ export const query = graphql`
     images {
       id
       title
-      fluid(maxWidth: 2560) {
+      fluid(sizes: "(max-width: 1024px) 400px, 1200px") {
         ...GatsbyContentfulFluid_withWebp
       }
     }

--- a/src/components/block-list.js
+++ b/src/components/block-list.js
@@ -36,7 +36,7 @@ export const query = graphql`
         url
       }
       fluid(
-        sizes: "(max-width: 480px) 640px, (max-width: 1024px) 1280px, 2048px"
+        sizes: "(max-width: 480px) 800px, (max-width: 1200px) 1200px, 2048px"
       ) {
         ...GatsbyContentfulFluid_withWebp
       }
@@ -52,7 +52,7 @@ export const query = graphql`
         url
       }
       fluid(
-        sizes: "(max-width: 480px) 640px, (max-width: 1024px) 1280px, 2618px"
+        sizes: "(max-width: 480px) 800px, (max-width: 1200px) 1200px, 2400px"
       ) {
         ...GatsbyContentfulFluid_withWebp
       }
@@ -82,7 +82,7 @@ export const query = graphql`
         url
       }
       fluid(
-        sizes: "(max-width: 480px) 640px, (max-width: 1024px) 1280px, 2618px"
+        sizes: "(max-width: 480px) 800px, (max-width: 1200px) 1200px, 2618px"
       ) {
         ...GatsbyContentfulFluid_withWebp
       }
@@ -101,7 +101,7 @@ export const query = graphql`
     image {
       title
       fluid(
-        sizes: "(max-width: 480px) 640px, (max-width: 1024px) 1280px, 2400px"
+        sizes: "(max-width: 480px) 800px, (max-width: 1200px) 1200px, 2400px"
       ) {
         ...GatsbyContentfulFluid_withWebp
       }
@@ -140,7 +140,7 @@ export const query = graphql`
     images {
       id
       title
-      fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
+      fluid(sizes: "(max-width: 1200px) 400px, 1600px") {
         ...GatsbyContentfulFluid_withWebp
       }
     }

--- a/src/components/block-list.js
+++ b/src/components/block-list.js
@@ -126,8 +126,10 @@ export const query = graphql`
       json
     }
     images {
-      file {
-        url
+      id
+      title
+      fluid(maxWidth: 2560) {
+        ...GatsbyContentfulFluid_withWebp
       }
     }
   }

--- a/src/components/block-list.js
+++ b/src/components/block-list.js
@@ -31,10 +31,13 @@ export const query = graphql`
     title
     subtitle
     image {
+      title
       file {
         url
       }
-      fluid(maxWidth: 2560) {
+      fluid(
+        sizes: "(max-width: 480px) 640px, (max-width: 1024px) 1280px, 2048px"
+      ) {
         ...GatsbyContentfulFluid_withWebp
       }
     }
@@ -44,10 +47,13 @@ export const query = graphql`
   fragment SectionBlock on ContentfulSectionBlock {
     id
     image {
+      title
       file {
         url
       }
-      fluid(maxWidth: 2560) {
+      fluid(
+        sizes: "(max-width: 480px) 640px, (max-width: 1024px) 1280px, 2618px"
+      ) {
         ...GatsbyContentfulFluid_withWebp
       }
     }
@@ -71,10 +77,13 @@ export const query = graphql`
     align
     images {
       id
+      title
       file {
         url
       }
-      fluid(maxWidth: 2560) {
+      fluid(
+        sizes: "(max-width: 480px) 640px, (max-width: 1024px) 1280px, 2618px"
+      ) {
         ...GatsbyContentfulFluid_withWebp
       }
     }
@@ -90,7 +99,10 @@ export const query = graphql`
   fragment OfficeBlock on ContentfulOfficeBlock {
     id
     image {
-      fluid(maxWidth: 2560) {
+      title
+      fluid(
+        sizes: "(max-width: 480px) 640px, (max-width: 1024px) 1280px, 2400px"
+      ) {
         ...GatsbyContentfulFluid_withWebp
       }
     }
@@ -128,7 +140,7 @@ export const query = graphql`
     images {
       id
       title
-      fluid(sizes: "(max-width: 1024px) 400px, 1200px") {
+      fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
         ...GatsbyContentfulFluid_withWebp
       }
     }
@@ -141,6 +153,7 @@ export const query = graphql`
       name
       position
       image {
+        title
         fluid(maxWidth: 400) {
           ...GatsbyContentfulFluid_withWebp
         }

--- a/src/components/content-footer.js
+++ b/src/components/content-footer.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { Link } from "gatsby"
+import Image from "gatsby-image"
 
 import styles from "./content-footer.module.css"
 import Legal from "./legal"
@@ -7,10 +8,13 @@ import Legal from "./legal"
 const ContentFooter = ({ title, subtitle, image, to }) => (
   <div className={styles.wrapperOuter}>
     <div className={styles.wrapperInner}>
-      <div
-        className={styles.backdrop}
-        style={{ backgroundImage: `url(https:${image})` }}
-      />
+      <div className={styles.backdrop}>
+        <Image
+          className={styles.img}
+          fluid={image.fluid}
+          alt={image.title || title}
+        />
+      </div>
       <div className={styles.content}>
         <Link to={to} className={styles.link}>
           <div>{subtitle}</div>

--- a/src/components/content-footer.module.css
+++ b/src/components/content-footer.module.css
@@ -29,6 +29,11 @@
   width: 100%;
 }
 
+.img {
+  height: 100%;
+  width: 100%;
+}
+
 .content {
   position: relative;
   z-index: 1;

--- a/src/components/content-list/item.js
+++ b/src/components/content-list/item.js
@@ -9,7 +9,7 @@ const Item = ({ to, title, subtitle, link, image }) => (
       <div className={styles.front}>{link}</div>
       {image}
     </div>
-    <h4 className={styles.title}>{title}</h4>
+    <h3 className={styles.title}>{title}</h3>
     <div className={styles.subtitle}>{subtitle}</div>
   </Link>
 )

--- a/src/components/content-list/item.module.css
+++ b/src/components/content-list/item.module.css
@@ -34,6 +34,7 @@
 }
 
 .title {
+  line-height: 1.5;
   margin-top: var(--spacing-xsmall);
 }
 

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -33,7 +33,7 @@ const Header = ({ title, subtitle, image }) => {
           {hasVideo ? (
             <Video src={`https:${image.file.url}`} />
           ) : (
-            <Image fluid={image.fluid} />
+            <Image fluid={image.fluid} alt={image.title} />
           )}
         </div>
       )}

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -28,7 +28,7 @@ const Navbar = () => {
       <header className={styles.wrapper}>
         <Link
           to="/"
-          aria-label="Wunderdog logo"
+          aria-label="Wunderdog home"
           className={`${styles.logo} ${
             logoHidden && !menuOpen ? styles.hidden : ""
           }`}

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -28,6 +28,7 @@ const Navbar = () => {
       <header className={styles.wrapper}>
         <Link
           to="/"
+          aria-label="Wunderdog logo"
           className={`${styles.logo} ${
             logoHidden && !menuOpen ? styles.hidden : ""
           }`}

--- a/src/components/section.js
+++ b/src/components/section.js
@@ -14,7 +14,7 @@ const Section = ({ children, image }) => {
           {hasVideo ? (
             <Video src={`https:${image.file.url}`} />
           ) : (
-            <Image fluid={image.fluid} />
+            <Image fluid={image.fluid} alt={image.title} />
           )}
         </div>
       )}

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -28,9 +28,9 @@ const renderSubtitle = (post, author) => (
   </>
 )
 
-const getMetaImage = (post) => {
-  let metaImage = null;
-  
+const getMetaImage = post => {
+  let metaImage = null
+
   if (post.image) {
     metaImage = post.image.fluid.src
   }
@@ -38,8 +38,8 @@ const getMetaImage = (post) => {
   if (post.metaImage) {
     metaImage = post.metaImage.fluid.src
   }
-  
-  return metaImage;
+
+  return metaImage
 }
 
 const BlogPost = ({ data }) => {
@@ -59,9 +59,11 @@ const BlogPost = ({ data }) => {
         />
       }
     >
-      <SEO 
+      <SEO
         title={post.metaTitle}
-        description={post.metaDescription ? post.metaDescription.metaDescription : null}         
+        description={
+          post.metaDescription ? post.metaDescription.metaDescription : null
+        }
         metaImage={metaImage}
         metaTwitterCardType={post.twitterSharePreviewType}
       />
@@ -85,7 +87,10 @@ export const query = graphql`
       title
       publishedAt(formatString: "MMM D, YYYY")
       image {
-        fluid(maxWidth: 2560) {
+        title
+        fluid(
+          sizes: "(max-width: 480px) 640px, (max-width: 1024px) 1280px, 2048px"
+        ) {
           ...GatsbyContentfulFluid_withWebp
         }
       }
@@ -98,7 +103,7 @@ export const query = graphql`
           src
         }
       }
-      twitterSharePreviewType,
+      twitterSharePreviewType
       video {
         file {
           url

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -54,7 +54,7 @@ const BlogPost = ({ data }) => {
         <ContentFooter
           title={next.title}
           subtitle="Go to next post"
-          image={next.image.fluid.src}
+          image={next.image}
           to={next.fields.route}
         />
       }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -209,7 +209,9 @@ export const query = graphql`
     next: contentfulBlogPost(slug: { eq: $next }) {
       title
       image {
-        fluid(maxWidth: 2560) {
+        fluid(
+          sizes: "(max-width: 786px) 800px, (max-width: 1200px) 1200px, 1600px"
+        ) {
           ...GatsbyContentfulFluid_withWebp
         }
       }
@@ -220,7 +222,9 @@ export const query = graphql`
     images: allContentfulAsset(filter: { file: { url: { in: $images } } }) {
       edges {
         node {
-          fluid(maxWidth: 2560) {
+          fluid(
+            sizes: "(max-width: 786px) 800px, (max-width: 1200px) 1200px, 2400px"
+          ) {
             ...GatsbyContentfulFluid_withWebp
           }
         }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -89,7 +89,7 @@ export const query = graphql`
       image {
         title
         fluid(
-          sizes: "(max-width: 480px) 640px, (max-width: 1024px) 1280px, 2048px"
+          sizes: "(max-width: 480px) 640px, (max-width: 1200px) 1280px, 2048px"
         ) {
           ...GatsbyContentfulFluid_withWebp
         }

--- a/src/templates/case-story.js
+++ b/src/templates/case-story.js
@@ -34,7 +34,7 @@ const CaseStory = ({ data }) => {
         <ContentFooter
           title={next.title}
           subtitle="Go to next case"
-          image={next.image.fluid.src}
+          image={next.image}
           to={next.fields.route}
         />
       }

--- a/src/templates/case-story.js
+++ b/src/templates/case-story.js
@@ -9,9 +9,9 @@ import BlockList from "../components/block-list"
 import RichText from "../components/rich-text"
 import ContentFooter from "../components/content-footer"
 
-const getMetaImage = (story) => {
-  let metaImage = null;
-  
+const getMetaImage = story => {
+  let metaImage = null
+
   if (story.image) {
     metaImage = story.image.fluid.src
   }
@@ -19,8 +19,8 @@ const getMetaImage = (story) => {
   if (story.metaImage) {
     metaImage = story.metaImage.fluid.src
   }
-  
-  return metaImage;
+
+  return metaImage
 }
 
 const CaseStory = ({ data }) => {
@@ -39,9 +39,11 @@ const CaseStory = ({ data }) => {
         />
       }
     >
-      <SEO 
-        title={story.metaTitle} 
-        description={story.metaDescription ? story.metaDescription.metaDescription : null}         
+      <SEO
+        title={story.metaTitle}
+        description={
+          story.metaDescription ? story.metaDescription.metaDescription : null
+        }
         metaImage={metaImage}
         metaTwitterCardType={story.twitterSharePreviewType}
       />
@@ -66,7 +68,8 @@ export const query = graphql`
     story: contentfulCaseStory(slug: { eq: $slug }) {
       title
       image {
-        fluid(maxWidth: 2560) {
+        title
+        fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
           ...GatsbyContentfulFluid_withWebp
         }
       }
@@ -79,7 +82,7 @@ export const query = graphql`
           src
         }
       }
-      twitterSharePreviewType,
+      twitterSharePreviewType
       video {
         file {
           url

--- a/src/templates/case-story.js
+++ b/src/templates/case-story.js
@@ -184,7 +184,9 @@ export const query = graphql`
     next: contentfulCaseStory(slug: { eq: $next }) {
       title
       image {
-        fluid(maxWidth: 2560) {
+        fluid(
+          sizes: "(max-width: 786px) 800px, (max-width: 1200px) 1200px, 1600px"
+        ) {
           ...GatsbyContentfulFluid_withWebp
         }
       }
@@ -195,7 +197,9 @@ export const query = graphql`
     images: allContentfulAsset(filter: { file: { url: { in: $images } } }) {
       edges {
         node {
-          fluid(maxWidth: 2560) {
+          fluid(
+            sizes: "(max-width: 786px) 800px, (max-width: 1200px) 1200px, 2400px"
+          ) {
             ...GatsbyContentfulFluid_withWebp
           }
         }

--- a/src/templates/case-story.js
+++ b/src/templates/case-story.js
@@ -69,7 +69,7 @@ export const query = graphql`
       title
       image {
         title
-        fluid(sizes: "(max-width: 1024px) 400px, 1600px") {
+        fluid(sizes: "(max-width: 1200px) 400px, 1600px") {
           ...GatsbyContentfulFluid_withWebp
         }
       }

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -8,8 +8,8 @@ import Article from "../components/article"
 import RichText from "../components/rich-text"
 import PageFooter from "../components/page-footer"
 
-const getMetaImage = (image) => {
-  return image ? image.fluid.src : null;
+const getMetaImage = image => {
+  return image ? image.fluid.src : null
 }
 
 const Page = ({ data }) => {
@@ -48,7 +48,7 @@ export const query = graphql`
           src
         }
       }
-      twitterSharePreviewType,
+      twitterSharePreviewType
       content {
         json
       }


### PR DESCRIPTION
Fixed the following issues according to Lighthouse recommendations:

- Added `font-display: swap;` to font CSS
- Fixed sequential heading issues (e.g. h5 shouldn't be under h2)
- Added an `aria-label` to Wunderdog logo which is also a home link
- Refactored customer logos on the home page to use `gatsby-image` instead of `img` tag
- Refactored `ContentFooter` to use `gatsby-image` instead of CSS background
- Added missing `alt` attributes to images + query image `title` 
- Changed image size querying to work better with smaller screens (the majority of changes)

Other fixes:

- Prettier reformatting
- Removed className that did not have a corresponding CSS class
